### PR TITLE
Fix for the context initalization on the parallella platform

### DIFF
--- a/platforms/parallella/barectf-platform-parallella.c
+++ b/platforms/parallella/barectf-platform-parallella.c
@@ -230,6 +230,9 @@ int tracing_init(void)
 	/* open first packet */
 	open_packet(&g_tracing_ctx);
 
+	/* acknowledge initalization */
+	g_tracing_ctx.initialized = 1;
+
 	return 0;
 }
 

--- a/platforms/parallella/barectf-platform-parallella.c
+++ b/platforms/parallella/barectf-platform-parallella.c
@@ -230,7 +230,7 @@ int tracing_init(void)
 	/* open first packet */
 	open_packet(&g_tracing_ctx);
 
-	/* acknowledge initalization */
+	/* acknowledge initialization */
 	g_tracing_ctx.initialized = 1;
 
 	return 0;

--- a/platforms/parallella/barectf-platform-parallella.c
+++ b/platforms/parallella/barectf-platform-parallella.c
@@ -76,7 +76,7 @@ static uint64_t get_clock(void* data)
 {
 	struct tracing_ctx *tracing_ctx = data;
 
-	uint64_t low = (uint64_t) ((uint32_t) -e_ctimer_get(E_CTIMER_1));
+	uint64_t low = (uint64_t) ((uint32_t)(E_CTIMER_MAX-e_ctimer_get(E_CTIMER_1)));
 
 	return tracing_ctx->clock_high | low;
 }
@@ -85,7 +85,7 @@ static int is_backend_full(void *data)
 {
 	struct tracing_ctx *tracing_ctx = data;
 	int check_shared = 0;
-	int full;
+	int full = 0;
 
 	/* are we in a back-end checking waiting period? */
 	if (tracing_ctx->backend_wait_period) {
@@ -141,7 +141,7 @@ static void close_packet(void *data)
 	 * buffer) for this packet, so "upload" it to shared memory now.
 	 */
 	index = get_prod_index(tracing_ctx) & (RINGBUF_SZ - 1);
-	dst = (void *) tracing_ctx->ringbuf->packets[index];
+	dst = (void *) &(tracing_ctx->ringbuf->packets[index]);
 	memcpy(dst, tracing_ctx->local_packet, PACKET_SZ);
 
 	/* update producer index after copy */


### PR DESCRIPTION
I ran into a bug while using barectf on the parallella platform : If there were multiple tracepoints in an eCore program then everything was nicely written by the eCore and retrieved by the consumer daemon. But, I figured that if the content of all tracepoints reached during an execution on the eCore wasn't big enough to fulfil a packet (that is to say that we use only one packet during the execution and that this packet is not full at the end of the program), then nothing happened.

 Apparently the problem is just a missing '1' in the 'initialized' field of the global tracing context of the eCore at the end of said initialization, causing the "tracing_fini()" function to not close the packet. This explains why the problem isn't to be expected when there is at least two packets, since the opening of a new packet automatically closes the previous one inside the barectf files (i.e without checking the good initialization of the context).